### PR TITLE
fix: VMAWARE_SERIALIZE breaks non-x86 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ For email inquiries: `vmaware.support@gmail.com`
 - [Adam Ruman](https://github.com/addam128)
 - [Juan Diego](https://github.com/w451)
 - [Wiisus](https://github.com/wiisus)
-- [Marcel](https://github.com/MarcelDev)
+- [Marcel](https://github.com/btwmarcel)
 - [Max Ufer](https://github.com/Manny684)
 - [Everdox](https://github.com/everdox)
 - [snackapps](https://github.com/snackapps)

--- a/src/vmaware.hpp
+++ b/src/vmaware.hpp
@@ -435,7 +435,7 @@
     #define TARGET_AVX512
 #endif
 
-#if (GCC || CLANG)
+#if (x86 && (GCC || CLANG))
     #define VMAWARE_SERIALIZE __attribute__((__target__("serialize")))
 #else
     #define VMAWARE_SERIALIZE


### PR DESCRIPTION
## What does this PR do?
- [ ] Add a new technique
- [ ] Add a new feature
- [ ] Add a new README translation
- [ ] Improve code
- [x] Fix bugs
- [ ] Refactoring or code organisation
- [ ] Stylistic changes
- [ ] Sync between branches
- [ ] Other

## Briefly explain what this PR does:

Only apply the `__target__("serialize")` attribute on x86
Without it, compilation on other architectures with GCC/clang fails with the error:
`vmaware.hpp:439:70: error: pragma or attribute 'target("serialize")' is not valid`